### PR TITLE
68 rename subnet to target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ This file lists all versions of the repository and precises all changes.
 #### Major changes :
 * There are more command line options
   * Port can now be overridden in the command line
-  * Subnet can now be overridden in the command line
+  * target can now be overridden in the command line
 * Bruteforce is now multithreaded and will use as many threads as there are discovered cameras
 * Thumbnail generation is now multithreaded and will use as many threads as there are discovered cameras
 * There are now default configuration values in order to make cameradar easier to use

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 #### Cameradar allows you to:
 
-* **Detect open RTSP hosts** on any accessible subnetwork
+* **Detect open RTSP hosts** on any accessible target
 * Get their public info (hostname, port, camera model, etc.)
 * Bruteforce your way into them to get their **stream route** (for example /live.sdp)
 * Bruteforce your way into them to get the **username and password** of the cameras
@@ -54,11 +54,11 @@ Run
 
 ```
 docker run  -v /tmp/thumbs/:/tmp/thumbs \
-            -e CAMERAS_SUBNETWORKS=your_subnetwork \
+            -e CAMERAS_TARGET=your_target \
             ullaakut/cameradar:tag
 ```
 
-* `your_subnetwork` can be a subnet (e.g.: `172.16.100.0/24`) or even an IP (e.g.: `172.16.100.10`), a range of IPs (e.g.: `172.16.100.10-172.16.100.20`) or a mix of all those (e.g.: `172.17.100.0/24,172.16.100.10-172.16.100.20,0.0.0.0`).
+* `your_target` can be a subnet (e.g.: `172.16.100.0/24`) or even an IP (e.g.: `172.16.100.10`), a range of IPs (e.g.: `172.16.100.10-172.16.100.20`) or a mix of all those separated by commas (e.g.: `172.17.100.0/24,172.16.100.10-172.16.100.20,0.0.0.0`).
 * `tag` allows you to specify a specific version for camerada. If you don't specify any tag, you will use the latest version by default (recommended)
 
 Check [Cameradar's readme on the Docker Hub](https://hub.docker.com/r/ullaakut/cameradar/) for more information and more command-line options.
@@ -84,7 +84,7 @@ The only dependencies are `docker`, `docker-tools`, `git` and `make`.
 
 By default, the version of the package in the deployment should be the last stable release.
 
-If you want to scan a different subnetwork or different ports, change the values `CAMERAS_SUBNETWORKS` and `CAMERAS_PORTS` in the `docker-compose.yml` file.
+If you want to scan a different target or different ports, change the values `CAMERAS_TARGET` and `CAMERAS_PORTS` in the `docker-compose.yml` file.
 
 The generated thumbnails will be in the `cameradar_thumbnails` folder after Cameradar has finished executing.
 
@@ -116,7 +116,7 @@ The simplest way would be to follow these steps :
 5. `cmake ..`
 6. `make`
 7. `cd cameradar_standalone`
-8. `./cameradar -s the_subnet_you_want_to_scan`
+8. `./cameradar -s the_target_you_want_to_scan`
 
 ## Advanced Docker deployment
 
@@ -159,7 +159,7 @@ Here is the basic content of the configuration file with simple placeholders :
      "password": "root",
      "db_name": "cmrdr"
   },
-  "subnets" : "SUBNET1,SUBNET2,SUBNET3,[...]",
+  "target" : "target1,target2,target3,[...]",
   "ports" : "PORT1,PORT2,[...]",
   "rtsp_url_file" : "/path/to/url/dictionary",
   "rtsp_ids_file" : "/path/to/url/dictionary",
@@ -173,7 +173,7 @@ This **configuration is needed only if you want to overwrite the default values*
 
 ```json
 {
-  "subnets" : "localhost",
+  "target" : "localhost",
   "ports" : "554,8554",
   "rtsp_url_file" : "conf/url.json",
   "rtsp_ids_file" : "conf/ids.json",
@@ -183,14 +183,14 @@ This **configuration is needed only if you want to overwrite the default values*
 }
 ```
 
-This means that **by default Cameradar will not use a database**, will scan localhost and the ports 554 (default RTSP port) and 8554 (default emulated RTSP port), use the default constructor dictionaries and store the thumbnails in `/tmp`. If you need to override simply the subnets or ports, you can use the [command line options](#command-line-options).
+This means that **by default Cameradar will not use a database**, will scan localhost and the ports 554 (default RTSP port) and 8554 (default emulated RTSP port), use the default constructor dictionaries and store the thumbnails in `/tmp`. If you need to override simply the target or ports, you can use the [command line options](#command-line-options).
 
-The subnetworks should be passed separated by commas only, and their subnet format should be the same as used in nmap.
+The targets should be passed separated by commas only, and their target format should be the same as used in nmap.
 ```json
-"subnets" : "172.100.16.0/24,172.100.17.0/24,localhost,192.168.1.13"
+"target" : "172.100.16.0/24,172.100.17.0/24,localhost,192.168.1.13"
 ```
 
-The **RTSP ports for most cameras are 554**, so you should probably specify 554 as one of the ports you scan. Not giving any ports in the configuration will scan every port of every host found on the subnetworks.
+The **RTSP ports for most cameras are 554**, so you should probably specify 554 as one of the ports you scan. Not giving any ports in the configuration will scan every port of every host found on the target.
 
 You **can use your own files for the ids and routes dictionaries** used to bruteforce the cameras, but the Cameradar repository already gives you a good base that works with most cameras.
 
@@ -230,7 +230,11 @@ If you're still in your console however, you can go even faster by using **vlc i
 ## Command line options
 
 * **"-c"** : Set a custom path to the configuration file (-c /path/to/conf)
+<<<<<<< HEAD
 * **"-s"** : Set custom subnets (overrides configuration) : You can use this argument in many ways, using a subnet (e.g.: `172.16.100.0/24`) or even an IP (e.g.: `172.16.100.10`), a range of IPs (e.g.: `172.16.100.10-172.16.100.20`) or a mix of all those (e.g.: `172.17.100.0/24,172.16.100.10-172.16.100.20,0.0.0.0`).
+=======
+* **"-s"** : Set custom target (overrides configuration)
+>>>>>>> 5489969... v2.0.0: Rename subnet to target to avoid confusion
 * **"-p"** : Set custom ports (overrides configuration)
 * **"-m"** : Set number of threads (*Default value : 1*)
 * **"-l"** : Set log level
@@ -267,7 +271,7 @@ Your camera probably uses GST RTSP Server internally. Try the `--gst-rtsp-server
 
 > Cameradar does not detect any camera!
 
-That means that either your cameras are not streaming in RTSP or that they are not on the subnetwork you are scanning. In most cases, CCTV cameras will be on a private subnetwork. Use the `-s` option to specify your camera's subnetwork.
+That means that either your cameras are not streaming in RTSP or that they are not on the target you are scanning. In most cases, CCTV cameras will be on a private subnetwork. Use the `-s` option to specify your target.
 
 > Cameradar detects my cameras, but does not manage to access them at all!
 

--- a/cameradar_standalone/conf/cameradar.conf.json
+++ b/cameradar_standalone/conf/cameradar.conf.json
@@ -6,7 +6,7 @@
     "password": "root",
     "db_name": "cmrdr"
   },
-  "subnets" : "localhost",
+  "target" : "localhost",
   "ports" : "554,8554",
   "rtsp_url_file" : "/cameradar/conf/url.json",
   "rtsp_ids_file" : "/cameradar/conf/ids.json",

--- a/cameradar_standalone/include/configuration.h
+++ b/cameradar_standalone/include/configuration.h
@@ -28,7 +28,7 @@ namespace cameradar {
 static const std::string default_configuration_path = "conf/cameradar.conf.json";
 
 static const std::string default_ports = "554,8554";
-static const std::string default_subnets = "localhost,168.0.0.0/24";
+static const std::string default_target = "localhost,168.0.0.0/24";
 static const std::string default_thumbnail_storage_path = "/tmp";
 static const std::string default_rtsp_url_file = "conf/url.json";
 static const std::string default_rtsp_ids_file = "conf/ids.json";
@@ -37,7 +37,7 @@ static const std::string default_cache_manager_name = "dumb";
 
 struct configuration {
     std::string thumbnail_storage_path;
-    std::string subnets;
+    std::string target;
     std::string rtsp_url_file;
     std::string rtsp_ids_file;
     std::string ports;
@@ -51,14 +51,14 @@ struct configuration {
 
     configuration() = default;
     configuration(const std::string& thumbnail_storage_path,
-                  const std::string& subnets,
+                  const std::string& target,
                   const std::string& rtsp_url_file,
                   const std::string& rtsp_ids_file,
                   const std::string& cache_manager_path,
                   const std::string& cache_manager_name,
                   const std::string& ports)
     : thumbnail_storage_path(thumbnail_storage_path)
-    , subnets(subnets)
+    , target(target)
     , rtsp_url_file(rtsp_url_file)
     , rtsp_ids_file(rtsp_ids_file)
     , ports(ports)

--- a/cameradar_standalone/src/configuration.cpp
+++ b/cameradar_standalone/src/configuration.cpp
@@ -136,10 +136,10 @@ serialize(const Json::Value& root) {
         else
             ret.second.ports = default_ports;
 
-        if (!root["subnets"].isNull())
-            ret.second.subnets = root["subnets"].asString();
+        if (!root["target"].isNull())
+            ret.second.target = root["target"].asString();
         else
-            ret.second.subnets = default_subnets;
+            ret.second.target = default_target;
 
         if (!root["rtsp_ids_file"].isNull())
             ret.second.rtsp_ids_file = root["rtsp_ids_file"].asString();
@@ -229,8 +229,8 @@ load(const std::pair<bool, etix::tool::opt_parse>& args) {
     conf.first &= conf.second.load_url();
     conf.first &= conf.second.load_ids();
 
-    if (args.second.exist("-s")) conf.second.subnets = args.second["-s"];
-    if (args.second.exist("-p")) conf.second.ports = args.second["-p"];
+    if (args.second.exist("-s")) conf.second.target = args.second["-s"];
+    if (args.second.exist("-p")) conf.second.target = args.second["-p"];
 
     return conf;
 }

--- a/cameradar_standalone/src/main.cpp
+++ b/cameradar_standalone/src/main.cpp
@@ -28,11 +28,11 @@ std::pair<bool, etix::tool::opt_parse>
 parse_cmdline(int argc, char* argv[]) {
     auto opt_parse = etix::tool::opt_parse{ argc, argv };
 
-    opt_parse.optional("-s", "Set subnets (e.g.: `172.16.0.0/24`)", true);
+    opt_parse.optional("-s", "Set target (e.g.: `172.16.0.0/24`)", true);
     opt_parse.optional("-p", "Set ports (e.g.: `554,8554`)", true);
     opt_parse.optional("-c", "Path to the configuration file (-c /path/to/conf)", true);
     opt_parse.optional("-l", "Set log level (-l 4 will only show warnings and errors)", true);
-    opt_parse.optional("-d", "Launch the discovery tool on the given subnet", false);
+    opt_parse.optional("-d", "Launch the discovery tool on the given target", false);
     opt_parse.optional("-b", "Launch the bruteforce tool on all discovered devices", false);
     opt_parse.optional("-t", "Generate thumbnails from detected cameras", false);
     opt_parse.optional("-g", "Check if the stream can be opened with GStreamer", false);

--- a/cameradar_standalone/src/tasks/mapping.cpp
+++ b/cameradar_standalone/src/tasks/mapping.cpp
@@ -34,16 +34,16 @@ nmap_is_ok() {
 }
 
 // Launches and checks the return of the nmap command
-// Uses the subnets specified in the conf file to launch nmap
+// Uses the target specified in the conf file to launch nmap
 bool
 mapping::run() const {
     if (nmap_is_ok()) {
-        std::string subnets = this->conf.subnets;
-        std::replace(subnets.begin(), subnets.end(), ',', ' ');
+        std::string target = this->conf.target;
+        std::replace(target.begin(), target.end(), ',', ' ');
         LOG_INFO_("Nmap 6.0 or greater found", "mapping");
         LOG_INFO_("Beginning mapping task. This may take a while.", "mapping");
         std::string cmd =
-            "nmap -T4 -A " + subnets + " -p " + this->conf.ports + " -oX " + nmap_output;
+            "nmap -T4 -A " + target + " -p " + this->conf.ports + " -oX " + nmap_output;
         LOG_DEBUG_("Launching nmap : " + cmd, "mapping");
         bool ret = launch_command(cmd);
         if (ret)

--- a/cameradar_standalone/src/tasks/parsing.cpp
+++ b/cameradar_standalone/src/tasks/parsing.cpp
@@ -20,7 +20,7 @@ namespace cameradar {
 static const std::string no_hosts_found_ =
     "No hosts were discovered on your network. Please check your internet "
     "connexion "
-    "and verify that the subnetworks you specified in your configuration file "
+    "and verify that the targetworks you specified in your configuration file "
     "were "
     "accessible";
 
@@ -79,7 +79,7 @@ parsing::print_detected_cameras(const std::vector<stream_model>& data) const {
         LOG_WARN_(
             "Mapping unsuccessful, no rtsp streams were discovered. You "
             "should try other "
-            "subnetworks",
+            "targetworks",
             "parsing");
         return false;
     }

--- a/cameradar_standalone/src/tasks/print.cpp
+++ b/cameradar_standalone/src/tasks/print.cpp
@@ -18,7 +18,7 @@ namespace etix {
 namespace cameradar {
 
 // Launches and checks the return of the nmap command
-// Uses the subnets specified in the conf file to launch nmap
+// Uses the specified targets in the conf file to launch nmap
 bool
 print::run() const {
     std::vector<stream_model> results = (*cache)->get_valid_streams();

--- a/deployment/conf/cameradar.tmpl.conf.json
+++ b/deployment/conf/cameradar.tmpl.conf.json
@@ -6,7 +6,7 @@
     "password": "$MYSQL_ROOT_PASSWORD",
     "db_name": "cmrdr"
   },
-  "subnets" : "$CAMERAS_SUBNETWORKS",
+  "target" : "$CAMERAS_TARGET",
   "ports" : "$CAMERAS_PORTS",
   "rtsp_url_file" : "/cameradar/conf/url.json",
   "rtsp_ids_file" : "/cameradar/conf/ids.json",

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "./cameradar_thumbnails:/tmp/thumbs"
       - ".:/tmp/shared"
     environment:
-     - CAMERAS_SUBNETWORKS=localhost
+     - CAMERAS_TARGET=localhost
      - CAMERAS_PORTS=554,8554
      - CACHE_MANAGER=dumb
      - MYSQL_ROOT_PASSWORD=root

--- a/deployment/docker-entrypoint.sh
+++ b/deployment/docker-entrypoint.sh
@@ -24,8 +24,8 @@ if [ "$CACHE_MANAGER" == "" ]; then
 	export CACHE_MANAGER="dumb"
 fi
 
-if [ "$CAMERAS_SUBNETWORKS" == "" ]; then
-	export CAMERAS_SUBNETWORKS="0.0.0.0"
+if [ "$CAMERAS_TARGET" == "" ]; then
+	export CAMERAS_TARGET="0.0.0.0"
 fi
 
 if [ "$CAMERAS_PORTS" == "" ]; then

--- a/test/conf/cameradar.conf.json
+++ b/test/conf/cameradar.conf.json
@@ -6,7 +6,7 @@
     "password": "root",
     "db_name": "cmrdr"
   },
-  "subnets" : "localhost",
+  "target" : "localhost",
   "ports" : "554,8554",
   "rtsp_url_file" : "/conf/url.json",
   "rtsp_ids_file" : "/conf/ids.json",


### PR DESCRIPTION
Since we can not only target subnets but also IPs, IP ranges and hostnames, renaming all subnet occurrences to target will improve the user experience.