### PR TITLE
v2.0.0: Rename bruteforce to dictionary attack to avoid confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ This file lists all versions of the repository and precises all changes.
 #### Major changes :
 * There are more command line options
   * Port can now be overridden in the command line
-  * target can now be overridden in the command line
+  * Target can now be overridden in the command line
 * Bruteforce is now multithreaded and will use as many threads as there are discovered cameras
 * Thumbnail generation is now multithreaded and will use as many threads as there are discovered cameras
 * There are now default configuration values in order to make cameradar easier to use
@@ -84,7 +84,7 @@ This file lists all versions of the repository and precises all changes.
 #### Minor changes :
 * The algorithms take external input into account (so that a 3rd party can change the DB to help Cameradar in real-time) and thus check the persistent data at each iteration
 * The default log level is now DEBUG instead of INFO
-* The bruteforce logs are now INFO instead of DEBUG
+* The attack logs are now INFO instead of DEBUG
 * The thumbnail generation logs are now INFO instead of DEBUG
 
 #### Bugs fixed
@@ -140,7 +140,7 @@ This file lists all versions of the repository and precises all changes.
 
 ## v0.2.2
 
-After doing some testing on a weirdly configured camera network in a far away Datacenter, I discovered that some Cameras needed a few tweaks to the Cameradar bruteforcing method in order to be accessed.
+After doing some testing on a weirdly configured camera network in a far away Datacenter, I discovered that some Cameras needed a few tweaks to the Cameradar attack method in order to be accessed.
 
 #### Major changes :
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 
 * **Detect open RTSP hosts** on any accessible target
 * Get their public info (hostname, port, camera model, etc.)
-* Bruteforce your way into them to get their **stream route** (for example /live.sdp)
-* Bruteforce your way into them to get the **username and password** of the cameras
+* Launch automated dictionary attacks to get their **stream route** (for example /live.sdp)
+* Launch automated dictionary attacks to get the **username and password** of the cameras
 * **Generate thumbnails** from them to check if the streams are valid and to have a quick preview of their content
 * Try to create a Gstreamer pipeline to check if they are **properly encoded**
 * Print a summary of all the informations Cameradar could get
@@ -192,7 +192,7 @@ The targets should be passed separated by commas only, and their target format s
 
 The **RTSP ports for most cameras are 554**, so you should probably specify 554 as one of the ports you scan. Not giving any ports in the configuration will scan every port of every host found on the target.
 
-You **can use your own files for the ids and routes dictionaries** used to bruteforce the cameras, but the Cameradar repository already gives you a good base that works with most cameras.
+You **can use your own files for the ids and routes dictionaries** used to attack the cameras, but the Cameradar repository already gives you a good base that works with most cameras.
 
 The thumbnail storage path should be a **valid and accessible directory** in which the thumbnails will be stored.
 
@@ -249,7 +249,7 @@ If you're still in your console however, you can go even faster by using **vlc i
   * **"-l 6"** : Log level CRITICAL
     * _Doesn't print anything since Cameradar can't have critical failures right now, however you can use this level to debug your own code easily or if you add new critical layers_
 * **"-d"** : Launch the discovery tool
-* **"-b"** : Launch the bruteforce tool on all discovered devices
+* **"-b"** : Launch the dictionary attack tool on all discovered devices
   * Needs either to be launched with the -d option or to use an advanced cache manager (DB, file, ...) with data already present
 * **"-t"** : Generate thumbnails from detected cameras
   * Needs either to be launched with the -d option or to use an advanced cache manager (DB, file, ...) with data already present
@@ -257,7 +257,7 @@ If you're still in your console however, you can go even faster by using **vlc i
   * Needs either to be launched with the -d option or to use an advanced cache manager (DB, file, ...) with data already present
 * **"-v"** : Display Cameradar's version
 * **"-h"** : Display this help
-* **"--gst-rtsp-server"** : Use this option if the bruteforce does not seem to work (only detects the username but not the path, or the opposite). This option will switch the order of the bruteforce to prioritize path over credentials, which is the way priority is handled for cameras that use GStreamer's RTSP server.
+* **"--gst-rtsp-server"** : Use this option if the attack does not seem to work (only detects the username but not the path, or the opposite). This option will switch the order of the attacks to prioritize path over credentials, which is the way priority is handled for cameras that use GStreamer's RTSP server.
 
 ## Contribution
 

--- a/cameradar_standalone/include/dispatcher.h
+++ b/cameradar_standalone/include/dispatcher.h
@@ -26,8 +26,8 @@
 // All the tasks managed by the dispatcher
 #include <tasks/mapping.h>
 #include <tasks/parsing.h>
-#include <tasks/brutelogs.h>
-#include <tasks/brutepath.h>
+#include <tasks/creds_attack.h>
+#include <tasks/path_attack.h>
 #include <tasks/thumbnail.h>
 #include <tasks/stream_check.h>
 #include <tasks/print.h>
@@ -40,8 +40,8 @@ enum class task {
     preparation,
     mapping,
     parsing,
-    brutepath,
-    bruteforce,
+    path_attack,
+    creds_attack,
     thumb_generation,
     print,
     finished

--- a/cameradar_standalone/include/tasks/creds_attack.h
+++ b/cameradar_standalone/include/tasks/creds_attack.h
@@ -16,34 +16,33 @@
 
 #include <cachemanager.h>   // cacheManager
 #include <cameradar_task.h> // task interface
-#include <curl/curl.h>      // cURL client for discovery
 #include <describe.h>       // send DESCRIBE through cURL
 #include <future>           // std::async & std::future
-#include <logger.h>         // LOG
-#include <memory>           // std::shared_ptr
 #include <signal_handler.h> // signals
 #include <stream_model.h>   // data model
 
 namespace etix {
 namespace cameradar {
 
-class brutepath : public etix::cameradar::cameradar_task {
+class creds_attack : public etix::cameradar::cameradar_task {
     const configuration& conf;
     std::shared_ptr<cache_manager> cache;
     std::string nmap_output;
 
 public:
-    brutepath() = delete;
-    brutepath(std::shared_ptr<cache_manager> cache,
+    creds_attack() = delete;
+    creds_attack(std::shared_ptr<cache_manager> cache,
               const configuration& conf,
               std::string nmap_output)
     : conf(conf), cache(cache), nmap_output(nmap_output) {}
-    brutepath(const brutepath& ref) = delete;
+    creds_attack(const creds_attack& ref) = delete;
 
     virtual bool run() const;
 
-    bool test_path(const etix::cameradar::stream_model& cit, const std::string& it) const;
-    bool bruteforce_camera(const stream_model& stream) const;
+    bool test_ids(const etix::cameradar::stream_model& cit,
+                  const std::string& pit,
+                  const std::string& uit) const;
+    bool attack_camera_creds(const stream_model& stream) const;
 };
 }
 }

--- a/cameradar_standalone/include/tasks/path_attack.h
+++ b/cameradar_standalone/include/tasks/path_attack.h
@@ -16,33 +16,34 @@
 
 #include <cachemanager.h>   // cacheManager
 #include <cameradar_task.h> // task interface
+#include <curl/curl.h>      // cURL client for discovery
 #include <describe.h>       // send DESCRIBE through cURL
 #include <future>           // std::async & std::future
+#include <logger.h>         // LOG
+#include <memory>           // std::shared_ptr
 #include <signal_handler.h> // signals
 #include <stream_model.h>   // data model
 
 namespace etix {
 namespace cameradar {
 
-class brutelogs : public etix::cameradar::cameradar_task {
+class path_attack : public etix::cameradar::cameradar_task {
     const configuration& conf;
     std::shared_ptr<cache_manager> cache;
     std::string nmap_output;
 
 public:
-    brutelogs() = delete;
-    brutelogs(std::shared_ptr<cache_manager> cache,
+    path_attack() = delete;
+    path_attack(std::shared_ptr<cache_manager> cache,
               const configuration& conf,
               std::string nmap_output)
     : conf(conf), cache(cache), nmap_output(nmap_output) {}
-    brutelogs(const brutelogs& ref) = delete;
+    path_attack(const path_attack& ref) = delete;
 
     virtual bool run() const;
 
-    bool test_ids(const etix::cameradar::stream_model& cit,
-                  const std::string& pit,
-                  const std::string& uit) const;
-    bool bruteforce_camera(const stream_model& stream) const;
+    bool test_path(const etix::cameradar::stream_model& cit, const std::string& it) const;
+    bool attack_camera_path(const stream_model& stream) const;
 };
 }
 }

--- a/cameradar_standalone/src/describe.cpp
+++ b/cameradar_standalone/src/describe.cpp
@@ -95,7 +95,7 @@ curl_describe(const std::string& path, bool logs) {
         // Some cameras timeout and then curl considers the status as 0
         // GST-RTSP-SERVER returns 404 instead of 401, then 401 instead of 404.
         if (rc != 401 && rc != 400 && rc && pos == std::string::npos)
-            LOG_INFO_("Unprotected camera discovered.", "brutelogs");
+            LOG_INFO_("Unprotected camera discovered.", "creds_attack");
         return ((res == CURLE_OK) && rc != 401 && rc != 400 && rc);
     }
     return ((res == CURLE_OK) && rc != 404 && rc != 400 && rc);

--- a/cameradar_standalone/src/dispatcher.cpp
+++ b/cameradar_standalone/src/dispatcher.cpp
@@ -64,11 +64,11 @@ dispatcher::do_stuff() {
     }
     if (opts.second.exist("-b")) {
         if (opts.second.exist("--gst-rtsp-server")) {
-            queue.push_back(new etix::cameradar::brutepath(cache, conf, nmap_output));
-            queue.push_back(new etix::cameradar::brutelogs(cache, conf, nmap_output));
+            queue.push_back(new etix::cameradar::path_attack(cache, conf, nmap_output));
+            queue.push_back(new etix::cameradar::creds_attack(cache, conf, nmap_output));
         } else {
-            queue.push_back(new etix::cameradar::brutelogs(cache, conf, nmap_output));
-            queue.push_back(new etix::cameradar::brutepath(cache, conf, nmap_output));
+            queue.push_back(new etix::cameradar::creds_attack(cache, conf, nmap_output));
+            queue.push_back(new etix::cameradar::path_attack(cache, conf, nmap_output));
         }
     }
     if (opts.second.exist("-t")) {
@@ -82,11 +82,11 @@ dispatcher::do_stuff() {
         queue.push_back(new etix::cameradar::mapping(cache, conf, nmap_output));
         queue.push_back(new etix::cameradar::parsing(cache, conf, nmap_output));
         if (opts.second.exist("--gst-rtsp-server")) {
-            queue.push_back(new etix::cameradar::brutepath(cache, conf, nmap_output));
-            queue.push_back(new etix::cameradar::brutelogs(cache, conf, nmap_output));
+            queue.push_back(new etix::cameradar::path_attack(cache, conf, nmap_output));
+            queue.push_back(new etix::cameradar::creds_attack(cache, conf, nmap_output));
         } else {
-            queue.push_back(new etix::cameradar::brutelogs(cache, conf, nmap_output));
-            queue.push_back(new etix::cameradar::brutepath(cache, conf, nmap_output));
+            queue.push_back(new etix::cameradar::creds_attack(cache, conf, nmap_output));
+            queue.push_back(new etix::cameradar::path_attack(cache, conf, nmap_output));
         }
         queue.push_back(new etix::cameradar::thumbnail(cache, conf, nmap_output));
         queue.push_back(new etix::cameradar::stream_check(cache, conf, nmap_output));

--- a/cameradar_standalone/src/main.cpp
+++ b/cameradar_standalone/src/main.cpp
@@ -33,14 +33,14 @@ parse_cmdline(int argc, char* argv[]) {
     opt_parse.optional("-c", "Path to the configuration file (-c /path/to/conf)", true);
     opt_parse.optional("-l", "Set log level (-l 4 will only show warnings and errors)", true);
     opt_parse.optional("-d", "Launch the discovery tool on the given target", false);
-    opt_parse.optional("-b", "Launch the bruteforce tool on all discovered devices", false);
+    opt_parse.optional("-b", "Launch the dictionary attack tool on all discovered devices", false);
     opt_parse.optional("-t", "Generate thumbnails from detected cameras", false);
     opt_parse.optional("-g", "Check if the stream can be opened with GStreamer", false);
     opt_parse.optional("-v", "Display Cameradar's version", false);
     opt_parse.optional("-h", "Display this help", false);
     opt_parse.optional(
         "--gst-rtsp-server",
-        "Change the order of the bruteforce to match GST RTSP Server's implementation of "
+        "Change the order of the attack to match GST RTSP Server's implementation of "
         "RTSP. Some cameras and RTSP servers will use this standard instead of the more "
         "standard one. For more information, see the README.md file.",
         false);

--- a/cameradar_standalone/src/tasks/parsing.cpp
+++ b/cameradar_standalone/src/tasks/parsing.cpp
@@ -114,7 +114,7 @@ parsing::run() const {
         if (data.size() == 0) { LOG_WARN_("No cameras were discovered", "parsing"); }
         return print_detected_cameras(data);
     } catch (const std::exception& e) {
-        LOG_ERR_("Error during parsing. brutepath aborted : " + std::string(e.what()), "parsing");
+        LOG_ERR_("Error during parsing. path_attack aborted : " + std::string(e.what()), "parsing");
         return false;
     }
 }


### PR DESCRIPTION
Using the terms `dictionary attack`, `credentials attack` and `path attack` instead of `bruteforce` will be more precise and help developers understand the code better as well as what the program actually does.