### PR TITLE
Use JSON-RPC to run cameradar service methods over WS

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,57 +1,28 @@
 hash: f646c12961eac693464d18f1ab91a7dd734514a1de59dfce2fe6de1507512bf7
-updated: 2017-10-20T08:57:53.219213734+02:00
+updated: 2017-10-31T09:52:06.986193695+01:00
 imports:
 - name: github.com/andelf/go-curl
   version: f8b334df3789fbdf98df3b3b22815e958b956c19
-- name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
-  subpackages:
-  - spew
 - name: github.com/fatih/color
   version: 570b54cabe6b8eb0bc2dfce68d964677d63b5260
 - name: github.com/gernest/wow
-  version: 8da164fc5bfb8099d4aceccb1c20d5934054723d
+  version: 57298475c6371a5a652e74dcf624c80edfc5ae1a
   subpackages:
   - spin
 - name: github.com/go-playground/locales
   version: e4cbcb5d0652150d40ad0646651076b6bd2be4f6
-  subpackages:
-  - currency
 - name: github.com/go-playground/universal-translator
   version: b32fa301c9fe55953584134cb6853a13c87ec0a1
 - name: github.com/gorilla/websocket
   version: ea4d1f681babbce9545c9c5f3d5194a789c89f5b
 - name: github.com/jessevdk/go-flags
   version: 96dc06278ce32a0e9d957d590bb987c81ee66407
-- name: github.com/mattn/go-colorable
-  version: 5411d3eea5978e6cdc258b30de592b60df6aba96
-  repo: https://github.com/mattn/go-colorable
-- name: github.com/mattn/go-isatty
-  version: 57fdcb988a5c543893cc61bce354a6e24ab70022
-  repo: https://github.com/mattn/go-isatty
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
-- name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
-  subpackages:
-  - difflib
-- name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
-  - assert
   - mock
-- name: golang.org/x/crypto
-  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
-  subpackages:
-  - ssh/terminal
-- name: golang.org/x/sys
-  version: e24f485414aeafb646f6fca458b0bf869c0880a1
-  repo: https://go.googlesource.com/sys
-  subpackages:
-  - unix
-  - windows
 - name: gopkg.in/go-playground/validator.v9
   version: a021b2ec9a8a8bb970f3f15bc42617cb520e8a64
 - name: gopkg.in/tylerb/graceful.v1

--- a/models.go
+++ b/models.go
@@ -12,17 +12,19 @@
 
 package cmrdr
 
+import "time"
+
 // Stream represents a camera's RTSP stream
 type Stream struct {
-	Device   string
-	Username string
-	Password string
-	Route    string
-	Address  string `validate:"required"`
-	Port     uint   `validate:"required"`
+	Device   string `json:"device"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Route    string `json:"route"`
+	Address  string `json:"address" validate:"required"`
+	Port     uint   `json:"port" validate:"required"`
 
-	CredentialsFound bool
-	RouteFound       bool
+	CredentialsFound bool `json:"credentials_found"`
+	RouteFound       bool `json:"route_found"`
 }
 
 // Credentials is a map of credentials
@@ -36,3 +38,14 @@ type Credentials struct {
 // Routes is a slice of Routes
 // ['/live.sdp', '/media.amp', ...]
 type Routes []string
+
+// Options contains all options needed to launch a complete cameradar scan
+type Options struct {
+	Target      string        `json:"target" validate:"required"`
+	Ports       string        `json:"ports"`
+	OutputFile  string        `json:"output_file"`
+	Routes      Routes        `json:"routes"`
+	Credentials Credentials   `json:"credentials"`
+	Speed       int           `json:"speed"`
+	Timeout     time.Duration `json:"timeout"`
+}

--- a/server/adaptor/jsonrpc2/jsonrpc2.go
+++ b/server/adaptor/jsonrpc2/jsonrpc2.go
@@ -1,0 +1,58 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonrpc2
+
+// http://www.jsonrpc.org/specification
+const (
+	ParseError     = -32700 // Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.
+	InvalidRequest = -32600 // The JSON sent is not a valid Request object.
+	MethodNotFound = -32601 // The method does not exist / is not available.
+	InvalidParams  = -32602 // Invalid method parameter(s).
+	InternalError  = -32603 // Internal JSON-RPC error.
+)
+
+const (
+	// ParseErrorMessage is the message associated with the ParseError error
+	ParseErrorMessage = "Parse error"
+	// InvalidRequestMessage is the message associated with the InvalidRequest error
+	InvalidRequestMessage = "Invalid Request"
+	// MethodNotFoundMessage is the message associated with the MethodNotFound error
+	MethodNotFoundMessage = "Method not found"
+	// InvalidParamsMessage is the message associated with the InvalidParams error
+	InvalidParamsMessage = "Invalid params"
+	// InternalErrorMessage is the message associated with the InternalError error
+	InternalErrorMessage = "Internal error"
+)
+
+// Request represents a JSONRPC request
+type Request struct {
+	JSONRPC string `json:"jsonrpc" validate:"eq=2.0"`
+	Method  string `json:"method" validate:"required"`
+	Params  string `json:"params" validate:"required"`
+	ID      string `json:"id"`
+}
+
+// Response represents a JSONRPC response
+type Response struct {
+	JSONRPC string `json:"jsonrpc" validate:"eq=2.0"`
+	Result  string `json:"result"`
+	Error   Error  `json:"error"`
+	ID      string `json:"id"`
+}
+
+// Error represents a JSONRPC response's error
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    string `json:"data"`
+}

--- a/server/adaptor/jsonrpc2/jsonrpc2.go
+++ b/server/adaptor/jsonrpc2/jsonrpc2.go
@@ -12,6 +12,8 @@
 
 package jsonrpc2
 
+import "github.com/EtixLabs/cameradar"
+
 // http://www.jsonrpc.org/specification
 const (
 	ParseError     = -32700 // Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.
@@ -36,18 +38,18 @@ const (
 
 // Request represents a JSONRPC request
 type Request struct {
-	JSONRPC string `json:"jsonrpc" validate:"eq=2.0"`
-	Method  string `json:"method" validate:"required"`
-	Params  string `json:"params" validate:"required"`
-	ID      string `json:"id"`
+	JSONRPC string        `json:"jsonrpc" validate:"eq=2.0"`
+	Method  string        `json:"method" validate:"required"`
+	Params  cmrdr.Options `json:"params" validate:"required"`
+	ID      string        `json:"id"`
 }
 
 // Response represents a JSONRPC response
 type Response struct {
-	JSONRPC string `json:"jsonrpc" validate:"eq=2.0"`
-	Result  string `json:"result"`
-	Error   Error  `json:"error"`
-	ID      string `json:"id"`
+	JSONRPC string         `json:"jsonrpc" validate:"eq=2.0"`
+	Result  []cmrdr.Stream `json:"result"`
+	Error   Error          `json:"error"`
+	ID      string         `json:"id"`
 }
 
 // Error represents a JSONRPC response's error

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1,0 +1,110 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/EtixLabs/cameradar"
+	"github.com/EtixLabs/cameradar/server/adaptor/jsonrpc2"
+	v "gopkg.in/go-playground/validator.v9"
+)
+
+func (c *Cameradar) handleRequest(message string) {
+	var ret []cmrdr.Stream
+	var JSONRPCErr jsonrpc2.Error
+
+	var request jsonrpc2.Request
+	err := json.Unmarshal([]byte(message), &request)
+	if err != nil {
+		JSONRPCErr = jsonrpc2.Error{
+			Code:    jsonrpc2.ParseError,
+			Message: jsonrpc2.ParseErrorMessage,
+			Data:    err.Error(),
+		}
+	}
+
+	validate := v.New()
+	err = validate.Struct(request)
+	if err != nil {
+		JSONRPCErr = jsonrpc2.Error{
+			Code:    jsonrpc2.InvalidRequest,
+			Message: jsonrpc2.InvalidRequestMessage,
+			Data:    err.Error(),
+		}
+	}
+
+	var options Options
+	err = json.Unmarshal([]byte(request.Params), &options)
+	if err != nil {
+		JSONRPCErr = jsonrpc2.Error{
+			Code:    jsonrpc2.InvalidParams,
+			Message: jsonrpc2.InvalidParamsMessage,
+			Data:    err.Error(),
+		}
+	}
+
+	c.SetOptions(options)
+
+	switch request.Method {
+	case "discover":
+		ret, err = c.Discover()
+	case "attack_credentials":
+		ret, err = c.Discover()
+	case "attack_routes":
+		ret, err = c.Discover()
+	case "discover_and_attack":
+		ret, err = c.DiscoverAndAttack()
+	default:
+		JSONRPCErr = jsonrpc2.Error{
+			Code:    jsonrpc2.MethodNotFound,
+			Message: jsonrpc2.MethodNotFoundMessage,
+			Data:    err.Error(),
+		}
+	}
+	if err != nil {
+		JSONRPCErr = jsonrpc2.Error{
+			Code:    jsonrpc2.InternalError,
+			Message: jsonrpc2.InternalErrorMessage,
+			Data:    err.Error(),
+		}
+	}
+
+	result, err := json.Marshal(ret)
+	if err != nil {
+		JSONRPCErr = jsonrpc2.Error{
+			Code:    jsonrpc2.InternalError,
+			Message: jsonrpc2.InternalErrorMessage,
+			Data:    err.Error(),
+		}
+	}
+	c.respondToClient(string(result), request.ID, JSONRPCErr)
+}
+
+func (c *Cameradar) respondToClient(result, ID string, JSONRPCErr jsonrpc2.Error) {
+	println(result)
+	r := jsonrpc2.Response{
+		JSONRPC: "2.0",
+		Result:  result,
+		Error:   JSONRPCErr,
+		ID:      ID,
+	}
+
+	response, err := json.Marshal(r)
+	if err != nil {
+		c.toClient <- "{\"jsonrpc\": \"2.0\",\"result\":null,\"error\":{\"code\":" + fmt.Sprint(jsonrpc2.InternalError) + ",\"" + jsonrpc2.InternalErrorMessage + "\",\"data\":\"could not marshal response\"},\"id\":\"" + ID + "\"}"
+	}
+
+	c.toClient <- string(response)
+}


### PR DESCRIPTION
Fixes #145.

The JSON-RPC implementation is very basic, homemade just this morning, and not tested. It seems to handle errors quite well and we currently can run methods independently or call the `discover_and_attack` method which asynchronously runs all steps and sends results through the WS continuously.

This code does repeat itself quite a lot and it's not very beautiful. There are clearly some improvements to be done there.